### PR TITLE
fix: constrain LayerPanel and PerformancePanel positions on window re…

### DIFF
--- a/src/components/ui/PerformancePanel.svelte
+++ b/src/components/ui/PerformancePanel.svelte
@@ -56,6 +56,45 @@ function initDefaultPosition() {
 	}
 }
 
+// Constrain panel position to be within viewport bounds
+function constrainPosition() {
+	const viewportWidth = window.innerWidth;
+	const viewportHeight = window.innerHeight;
+
+	// Panel min-width is 280px (from CSS)
+	const panelWidth = 280;
+
+	// Constrain position
+	let newX = panelPosition.x;
+	let newY = panelPosition.y;
+
+	// Ensure at least part of the panel is visible
+	const minVisiblePx = 50;
+
+	if (newX + panelWidth < minVisiblePx) {
+		newX = minVisiblePx - panelWidth;
+	}
+	if (newX > viewportWidth - minVisiblePx) {
+		newX = viewportWidth - minVisiblePx;
+	}
+	if (newY < 0) {
+		newY = 0;
+	}
+	if (newY > viewportHeight - minVisiblePx) {
+		newY = viewportHeight - minVisiblePx;
+	}
+
+	if (newX !== panelPosition.x || newY !== panelPosition.y) {
+		panelPosition = { x: newX, y: newY };
+		saveState();
+	}
+}
+
+// Handle window resize
+function handleWindowResize() {
+	constrainPosition();
+}
+
 // Drag handlers
 function handlePointerStart(clientX: number, clientY: number) {
 	mouseDownTime = Date.now();
@@ -144,6 +183,7 @@ let updateInterval: number | null = null;
 onMount(() => {
 	loadState();
 	initDefaultPosition();
+	window.addEventListener("resize", handleWindowResize);
 	updateInterval = window.setInterval(() => {
 		if (renderer && visible) {
 			metrics = renderer.getPerformanceMetrics();
@@ -152,6 +192,7 @@ onMount(() => {
 });
 
 onDestroy(() => {
+	window.removeEventListener("resize", handleWindowResize);
 	if (updateInterval !== null) {
 		clearInterval(updateInterval);
 	}


### PR DESCRIPTION
…size

- Add constrainPosition() function to both panels (following Minimap pattern)
- Add handleWindowResize() event listener to keep panels within viewport
- Ensure at least 50px of panel remains visible after resize
- Add proper cleanup in onDestroy() to remove event listeners

Fixes #42